### PR TITLE
Inform twitter-text of URL entities

### DIFF
--- a/src/renderer/components/retweet.js
+++ b/src/renderer/components/retweet.js
@@ -29,7 +29,7 @@ export default class Retweet extends React.Component {
             </div>
             <Time className="tweet-datetime" time={this.props.tweet.created_at} />
           </div>
-          <div className="tweet-body" dangerouslySetInnerHTML={{__html: twitterText.autoLink(this.props.tweet.retweeted_status.text)}} />
+          <div className="tweet-body" dangerouslySetInnerHTML={{__html: twitterText.autoLink(this.props.tweet.retweeted_status.text, {urlEntities: this.props.tweet.retweeted_status.entities.urls})}} />
         </div>
       </li>
     );

--- a/src/renderer/components/tweet.js
+++ b/src/renderer/components/tweet.js
@@ -21,7 +21,7 @@ export default class Tweet extends React.Component {
             </div>
             <Time className="tweet-datetime" time={this.props.tweet.created_at} />
           </div>
-          <div className="tweet-body" dangerouslySetInnerHTML={{__html: twitterText.autoLink(this.props.tweet.text)}} />
+          <div className="tweet-body" dangerouslySetInnerHTML={{__html: twitterText.autoLink(this.props.tweet.text, {urlEntities: this.props.tweet.entities.urls})}} />
         </div>
       </li>
     );


### PR DESCRIPTION
By informing it of URL entities, almost all `https://t.co` links are replaced by `display_url`.

Please see https://github.com/twitter/twitter-text/tree/master/js#auto-linking-examples.
